### PR TITLE
fix exit call - node 18 on k8s docker does not terminate without it [GEN-2004]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-process-exit */
+/* eslint-disable n/no-process-exit */
+
 import { Command } from 'commander'
 import { setCliContext } from './context'
 import { configureLogger } from '@marinade.finance/cli-common'
@@ -62,6 +65,7 @@ installCommands(program)
 program.parseAsync(process.argv).then(
   () => {
     logger.debug({ resolution: 'Success', args: process.argv })
+    process.exit(0)
   },
   (err: Error) => {
     logger.error(
@@ -70,7 +74,6 @@ program.parseAsync(process.argv).then(
         : err.message,
     )
     logger.debug({ resolution: 'Failure', err, args: process.argv })
-
-    process.exitCode = 1
+    process.exit(1)
   },
 )

--- a/src/notifier.ts
+++ b/src/notifier.ts
@@ -57,8 +57,9 @@ export async function sendNotifications(
   }
 
   const results = await Promise.allSettled(
-    notifications.map(notification =>
-      sendNotification(notification, messageWithProposalId),
+    notifications.map(
+      async notification =>
+        await sendNotification(notification, messageWithProposalId),
     ),
   )
 
@@ -81,16 +82,16 @@ async function sendNotification(
 ): Promise<void> {
   switch (notification.type) {
     case NotificationType.WEBHOOK:
-      return sendWebhookNotification(notification, message)
+      return await sendWebhookNotification(notification, message)
 
     case NotificationType.TELEGRAM:
-      return sendTelegramNotification(notification, message)
+      return await sendTelegramNotification(notification, message)
 
     case NotificationType.DISCORD:
-      return sendDiscordNotification(notification, message)
+      return await sendDiscordNotification(notification, message)
 
     case NotificationType.SLACK:
-      return sendSlackNotification(notification, message)
+      return await sendSlackNotification(notification, message)
 
     default:
       getContext().logger.warn('No notifications type configured for sending')


### PR DESCRIPTION
The docker image on nodejs18 does not want to finish without explicitly stating the exit call.