### PR TITLE
[fix] do not double notify

### DIFF
--- a/src/commands/check-proposals.ts
+++ b/src/commands/check-proposals.ts
@@ -217,7 +217,8 @@ export async function checkProposals({
     const remainingVotingBaseTimeInSeconds =
       baseVotingTime + proposal.account.votingAt.toNumber() - currentTimestamp
     if (
-      remainingVotingBaseTimeInSeconds >= oneDayInSeconds - lookBackPeriod &&
+      remainingVotingBaseTimeInSeconds >=
+        oneDayInSeconds - toleranceInSeconds &&
       remainingVotingBaseTimeInSeconds <
         oneDayInSeconds + lookBackPeriod + toleranceInSeconds
     ) {


### PR DESCRIPTION
The SPL Gov notifier checks the existence of on-chain data and verifies if a proposal was created recently.
The processing tends to double notify about proposals that are about 1 day from voting to be closed.
The current check double calculates the `lookBackPeriod`, which is a time period of the last check and the current time (when the cron execution was launched).
The whole checks are not super precise as the system do not tracks on what were announced proposals and which were not announced. But this may halp for mitigation of double announcement.